### PR TITLE
fix: undefined variable  en flotaId

### DIFF
--- a/app/Http/Controllers/ServiceSatelital.php
+++ b/app/Http/Controllers/ServiceSatelital.php
@@ -1243,8 +1243,9 @@ class ServiceSatelital extends Controller
                     'carnet' => $camion->vto_carnet,
                     'whatsapp' => $camion->WhatsApp,
                 );
+
+                array_push($camiones, $truck);
             }
-            array_push($camiones, $truck);
         }
 
         return $camiones;


### PR DESCRIPTION
## Summary
- Mueve `array_push($camiones, $truck)` dentro del bloque `if ($unidad->isNotEmpty())` en `ServiceSatelital.php`
- Fix para Sentry [API-BTZ-3](https://rail-g6.sentry.io/issues/7395637752/): `ErrorException: Undefined variable $truck` en `/api/flotaId/{id}` cuando una unidad no tiene contenedores activos

## Test plan
- [ ] Verificar que `/api/flotaId/{id}` responde correctamente con unidades que tienen cargas activas
- [ ] Verificar que no crashea con unidades sin cargas activas

🤖 Generated with [Claude Code](https://claude.com/claude-code)